### PR TITLE
increase number of retries and delay before retry for more consistent…

### DIFF
--- a/dbt/adapters/spark_cde/cdeapisession.py
+++ b/dbt/adapters/spark_cde/cdeapisession.py
@@ -32,8 +32,8 @@ from dbt.utils import DECIMALS
 logger = AdapterLogger("Spark")
 
 DEFAULT_POLL_WAIT = 2 # seconds
-DEFAULT_LOG_WAIT = 5 # seconds
-DEFAULT_RETRIES = 5 # max number of retries for fetching log
+DEFAULT_LOG_WAIT = 10 # seconds
+DEFAULT_RETRIES = 10 # max number of retries for fetching log
 NUMBERS = DECIMALS + (int, float)
 
 class CDEApiCursor:


### PR DESCRIPTION
increase number of retries and delay before retry for more consistent job result fetch via job-runs/{id}/logs api


