### PR TITLE
add usage tracking (Cloudera specific) to spark_cde adapter

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,0 +1,5 @@
+# modify and copy this file to dbt/adapters/spark_cde/.env
+SNOWPLOW_ENDPOINT=[https://events-end-point-url.com/events]
+SNOWPLOW_TIMEOUT=10
+SNOWPLOW_API_KEY=[xyzSECRECT_KEYxyz]
+SNOWPLOW_ENNV=prod

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ test.env
 .spark-warehouse/
 dbt-integration-tests
 test/integration/.user.yml
+
+.env

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include dbt/include *.sql *.yml *.md
+recursive-include dbt/adapter *.env

--- a/dbt/adapters/spark_cde/connections.py
+++ b/dbt/adapters/spark_cde/connections.py
@@ -43,6 +43,10 @@ except ImportError:
 import base64
 import time
 
+import json
+import hashlib
+import threading
+
 logger = AdapterLogger("Spark")
 
 NUMBERS = DECIMALS + (int, float)
@@ -81,6 +85,7 @@ class SparkCredentials(Credentials):
     use_ssl: bool = False
     server_side_parameters: Dict[str, Any] = field(default_factory=dict)
     retry_all: bool = False
+    usage_tracking: Optional[bool] = True
 
     @classmethod
     def __pre_deserialize__(cls, data):
@@ -450,6 +455,21 @@ class SparkConnectionManager(SQLConnectionManager):
                     handle = SessionConnectionWrapper(Connection())
                 elif creds.method == SparkConnectionMethod.CDE:
                     handle = CDEApiSessionConnectionWrapper(CDEApiConnectionManager().connect(creds.user, creds.password, creds.auth_endpoint, creds.host))
+                    try:
+                        if (creds.usage_tracking):
+                            tracking_data = {}
+                            payload = {}
+                            payload["id"] = "dbt_spark_cde_open"
+                            payload["unique_hash"] = hashlib.md5(creds.host.encode()).hexdigest()
+                            payload["auth"] = "cde"
+                            payload["connection_state"] = connection.state
+
+                            tracking_data["data"] = payload
+
+                            the_track_thread = threading.Thread(target=track_usage, kwargs={"data": tracking_data})
+                            the_track_thread.start()
+                    except:
+                        logger.debug("Usage tracking error")
                 else:
                     raise dbt.exceptions.DbtProfileError(
                         f"invalid credential method: {creds.method}"
@@ -540,3 +560,21 @@ def _is_retryable_error(exc: Exception) -> str:
         return str(exc)
     else:
         return ""
+
+# usage tracking code - Cloudera specific
+def track_usage(data):
+   import requests
+   from decouple import config
+
+   SNOWPLOW_ENDPOINT = config('SNOWPLOW_ENDPOINT')
+   SNOWPLOW_TIMEOUT  = int(config('SNOWPLOW_TIMEOUT')) # 10 seconds
+
+   # prod creds
+   headers = {'x-api-key': config('SNOWPLOW_API_KEY'), 'x-datacoral-environment': config('SNOWPLOW_ENNV'), 'x-datacoral-passthrough': 'true'}
+
+   data = json.dumps([data])
+
+   res = requests.post(SNOWPLOW_ENDPOINT, data = data, headers = headers, timeout = SNOWPLOW_TIMEOUT)
+
+   return res
+

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
     author_email="info@dbtlabs.com",
     url="https://github.com/dbt-labs/dbt-spark",
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
+    data_files=[('', ['dbt/adapters/spark_cde/.env'])],
     include_package_data=True,
     install_requires=[
         "dbt-core~={}".format(dbt_core_version),


### PR DESCRIPTION
Internal Ticket: https://jira.cloudera.com/browse/DBT-145

Testplan:

copy .env_example to dbt/adapters/spark_cde/.env
edit dbt/adapters/spark_cde/.env and change SNOWPLOW_ENDPOINT and SNOWPLOW_API_KEY to appropriate values
run dbt debug
check if instrumentation data is being recoded, see ticket internal ticket (https://jira.cloudera.com/browse/DBT-68)
Build and tested with the following settings of .env_example
SNOWPLOW_ENDPOINT=https://dcevents.cldrteam.datacoral.io/cldrteam/apievents
SNOWPLOW_TIMEOUT=10
SNOWPLOW_API_KEY=-ProductionKey-
SNOWPLOW_ENNV=prod
