### PR TITLE
Add logging of cde job runs,sessions and logs

### DIFF
--- a/dbt/adapters/spark_cde/cdeapisession.py
+++ b/dbt/adapters/spark_cde/cdeapisession.py
@@ -119,24 +119,34 @@ class CDEApiCursor:
     
         # 3. run the job
         job_status = self._cde_connection.getJobRunStatus(job).json()
-        
-        # 4. wait for the result       
-        while job_status["status"] != CDEApiConnection.JOB_STATUS['succeeded']:
+
+        # 4. wait for the result
+        while (job_status["status"] != CDEApiConnection.JOB_STATUS['succeeded']) or (job_status["status"] == CDEApiConnection.JOB_STATUS['failed']):
             time.sleep(DEFAULT_POLL_WAIT)
             job_status = self._cde_connection.getJobRunStatus(job).json()
 
-            if (job_status["status"] == CDEApiConnection.JOB_STATUS['failed']):
-                print("Job Failed", sql, job_status)
-                raise dbt.exceptions.raise_database_error(
-                        'Error while executing query: ' + repr(job_status)
-                    ) 
+        logger.debug("***************CDE JOB DEBUGGING START: ******************")
+        logger.debug("Job created with id: {}".format(job_name))
+        logger.debug("Job created with sql statement: {}".format(sql))
+        logger.debug("Job status: {}".format(job_status["status"]))
+        logger.debug("Job run other details: {}".format(job_status))
+        logger.debug("***************CDE JOB DEBUGGING END:  ******************")
 
+        # throw exception and print to console for failed job.
+        if (job_status["status"] == CDEApiConnection.JOB_STATUS['failed']):
+            print("Job Failed", sql, job_status)
+            raise dbt.exceptions.raise_database_error(
+                'Error while executing query: ' + repr(job_status)
+            )
+            
         # 5. fetch and populate the results 
         time.sleep(DEFAULT_LOG_WAIT) # wait before trying to access the log - so as to ensure that the logs are written to the bucket
         # print("execute - sql", job, sql)
         # log_types = self._cde_connection.getJobLogTypes(job)
         # print("execute - log_types", log_types)
+        logger.debug("***************CDE SESSION LOG START:  ******************")
         schema, rows = self._cde_connection.getJobOutput(job)
+        logger.debug("***************CDE SESSION LOG END:  ******************")
 
         self._rows = rows
         self._schema = schema 
@@ -315,6 +325,8 @@ class CDEApiConnection:
 
             time.sleep(DEFAULT_LOG_WAIT)
             
+        logger.debug("Log result stdout: {}".format(res.text.split("\n")))
+        
         line_number = 0
         for line in res_lines:
             line_number += 1


### PR DESCRIPTION
Tested by doing a dbt seed and run to see that session id, job sql, job status and job output are logged.

Succesful run

![image](https://user-images.githubusercontent.com/2308360/186604002-042923f2-372f-4bf4-8752-1b93130a4a68.png)

Failed run
![image](https://user-images.githubusercontent.com/2308360/186668396-40a2fe65-0a52-4e48-8eec-fa958df74ea3.png)
