### PR TITLE
Updates to profiling for cde session 

### DIFF
--- a/dbt/adapters/spark_cde/adaptertimer.py
+++ b/dbt/adapters/spark_cde/adaptertimer.py
@@ -1,4 +1,6 @@
 import time
+import datetime
+
 from dbt.events import AdapterLogger
 logger = AdapterLogger("Spark")
 
@@ -44,4 +46,6 @@ class AdapterTimer:
     def log_summary(self, job_name):
         logger.debug("\n")
         for timer in self._timers:
-            logger.debug("{job_name:<40}{name:<40}{elapsed:20.2f}".format(job_name= job_name+ "\t", name=timer["name"], elapsed=timer["elapsed_time"]))
+            start_time_utc = datetime.datetime.utcfromtimestamp(timer["start_time"]).time().strftime('%H:%M:%S.%f')
+            end_time_utc = datetime.datetime.utcfromtimestamp(timer["end_time"]).time().strftime('%H:%M:%S.%f')
+            logger.debug("{:<40}{:<40}{:20}{:20}{:10.2f}".format(job_name+ "\t", timer["name"],start_time_utc , end_time_utc, timer["elapsed_time"]))

--- a/dbt/adapters/spark_cde/adaptertimer.py
+++ b/dbt/adapters/spark_cde/adaptertimer.py
@@ -41,7 +41,7 @@ class AdapterTimer:
             print("Timer ", timer_name, " not found")
         return None
 
-    def log_summary(self):
-        logger.debug("Job name\t\t\telapsed(in secs)")
+    def log_summary(self, job_name):
+        logger.debug("\n")
         for timer in self._timers:
-            logger.debug("{name:<20}{elapsed:10.2f}".format(name=timer["name"], elapsed=timer["elapsed_time"]))
+            logger.debug("{job_name:<40}{name:<40}{elapsed:20.2f}".format(job_name= job_name+ "\t", name=timer["name"], elapsed=timer["elapsed_time"]))

--- a/dbt/adapters/spark_cde/cdeapisession.py
+++ b/dbt/adapters/spark_cde/cdeapisession.py
@@ -34,8 +34,8 @@ from dbt.adapters.spark_cde.adaptertimer import AdapterTimer
 logger = AdapterLogger("Spark")
 adapter_timer = AdapterTimer()
 
-DEFAULT_POLL_WAIT = 5 # seconds
-DEFAULT_LOG_WAIT = 20 # seconds
+DEFAULT_POLL_WAIT = 2 # seconds
+DEFAULT_LOG_WAIT = 10 # seconds
 DEFAULT_RETRIES = 10 # max number of retries for fetching log
 MIN_LINES_TO_PARSE = 3 # minimum lines in the logs file before we can start to parse the sql output 
 NUMBERS = DECIMALS + (int, float)


### PR DESCRIPTION
Updated profiling with 

- Count time waiting in sleep and log it
- Fetch spark job events and log it
- Format log error (sql query execution not successful) and print it as error.
- Attach session id to logs

sample dbt seed that shows both queries failing and passing
[dbt.log](https://github.com/cloudera/dbt-spark-cde/files/9449619/dbt.log)
