### PR TITLE
Refactor cdesession code

### DIFF
--- a/dbt/adapters/spark_cde/cdeapisession.py
+++ b/dbt/adapters/spark_cde/cdeapisession.py
@@ -35,7 +35,7 @@ logger = AdapterLogger("Spark")
 adapter_timer = AdapterTimer()
 
 DEFAULT_POLL_WAIT = 30  # time to sleep in seconds before re-fetching job status
-DEFAULT_LOG_WAIT = 10  # time to wait in seconds for logs to be populated after job run
+DEFAULT_LOG_WAIT = 40  # time to wait in seconds for logs to be populated after job run
 DEFAULT_CDE_JOB_TIMEOUT = (
     900  # max amount of time(in secs) to keep retrying for fetching job status
 )
@@ -202,13 +202,11 @@ class CDEApiCursor:
 
         # 6. fetch and populate the results
         logger.debug("{}: Get job output".format(job_name))
-        schema, rows, job_output = self._cde_connection.get_job_output(job_name, job)
+        schema, rows, success_job_output = self._cde_connection.get_job_output(job_name, job)
         logger.debug("{}: Done get job output".format(job_name))
-        logger.debug("{}: Job output details: {}".format(job_name, job_output.text))
+        logger.debug("{}: Job output details: {}".format(job_name, success_job_output.text))
         self._rows = rows
         self._schema = schema
-
-        self.get_spark_job_events(job_name, job)
 
         # 7. cleanup resources
         logger.debug("{}: Delete job".format(job_name))

--- a/dbt/adapters/spark_cde/cdeapisession.py
+++ b/dbt/adapters/spark_cde/cdeapisession.py
@@ -35,7 +35,7 @@ logger = AdapterLogger("Spark")
 adapter_timer = AdapterTimer()
 
 DEFAULT_POLL_WAIT = 30  # time to sleep in seconds before re-fetching job status
-DEFAULT_LOG_WAIT = 15  # time to sleep in seconds for logs to be populated
+DEFAULT_LOG_WAIT = 10  # time to wait in seconds for logs to be populated after job run
 DEFAULT_CDE_JOB_TIMEOUT = (
     900  # max amount of time(in secs) to keep retrying for fetching job status
 )
@@ -450,10 +450,10 @@ class CDEApiConnection:
         self, job_name, job, log_type="stdout"
     ):  # log_type can be "stdout", "stderr", "event"
 
-        # logger.debug("{}: Sleep for {} seconds".format(job_name, DEFAULT_LOG_WAIT))
-        # # Introducing a wait as job logs can take few secs to be populated after job completion.
-        # time.sleep(DEFAULT_LOG_WAIT)
-        # logger.debug("{}: Done sleep for {} seconds".format(job_name, DEFAULT_LOG_WAIT))
+        logger.debug("{}: Sleep for {} seconds".format(job_name, DEFAULT_LOG_WAIT))
+        # Introducing a wait as job logs can take few secs to be populated after job completion.
+        time.sleep(DEFAULT_LOG_WAIT)
+        logger.debug("{}: Done sleep for {} seconds".format(job_name, DEFAULT_LOG_WAIT))
         req_url = self.base_api_url + "job-runs" + "/" + repr(job["id"]) + "/logs"
         params = {"type": "driver" + "/" + log_type, "follow": "true"}
         res = requests.get(req_url, params=params, headers=self.api_header)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pyodbc>=4.0.30
 sqlparams>=3.0.0
 thrift>=0.13.0
 sqlparse>=0.4.2 # not directly required, pinned by Snyk to avoid a vulnerability
+
+requests~=2.28.1


### PR DESCRIPTION
This pr includes the following:

- Formatting to confirm to pep8 standards
- Properly randomize the job name
- Introduce time out while polling job status so as not to be a resource hog.
- Refactor method names to make them have uniform style(snake case) and cleanup redundant sleeps
- Introduced method to show spark events from logs if necessary(currently disabled as fetching logs adds to latency)

**Testing:**

- Tested by performing a dbt seed and run on covid data. To follow the logs you can do a grep on jobname to see what queries have failed/passed, their outputs and the stages any particular job run goes through.
- dbt seed has some sql queries that is expected to fail on execution and is now surfaced through logs.
- dbt test was performed with spark events logging enabled.
[dbt.log](https://github.com/cloudera/dbt-spark-cde/files/9469089/dbt.log)
[dbt-seed.log](https://github.com/cloudera/dbt-spark-cde/files/9469088/dbt-seed.log)
[dbt-test.log](https://github.com/cloudera/dbt-spark-cde/files/9469368/dbt-test.log)

