### PR TITLE
Add ability to pass CDE session parameters via dbt profile.

### DIFF
--- a/dbt/adapters/spark_cde/cdeapisession.py
+++ b/dbt/adapters/spark_cde/cdeapisession.py
@@ -320,10 +320,11 @@ class CDEApiConnection:
         "failed": "failed",
     }
 
-    def __init__(self, base_api_url, access_token, api_header) -> None:
+    def __init__(self, base_api_url, access_token, api_header, session_params) -> None:
         self.base_api_url = base_api_url
         self.access_token = access_token
         self.api_header = api_header
+        self.session_params = session_params
 
     def create_resource(self, resource_name, resource_type):
         params = {"hidden": False, "name": resource_name, "type": resource_type}
@@ -380,6 +381,10 @@ class CDEApiConnection:
         params["spark"]["file"] = py_resource["file_name"]
         params["spark"]["files"] = [sql_resource["file_name"]]
         params["spark"]["conf"] = {"spark.pyspark.python": "python3"}
+
+        # add user specified session parameters
+        for key, value in self.session_params.items():
+            params["spark"]["conf"][key] = value
 
         res = requests.post(
             self.base_api_url + "jobs", data=json.dumps(params), headers=self.api_header
@@ -578,6 +583,7 @@ class CDEApiConnectionManager:
         self.password = ""
         self.access_token = ""
         self.api_headers = {}
+        self.session_params = {}
 
     def get_base_auth_url(self):
         return self.base_auth_url
@@ -588,11 +594,12 @@ class CDEApiConnectionManager:
     def get_auth_endpoint(self):
         return self.get_base_auth_url() + "gateway/authtkn/knoxtoken/api/v1/token"
 
-    def connect(self, user_name, password, base_auth_url, base_api_url):
+    def connect(self, user_name, password, base_auth_url, base_api_url, session_params):
         self.base_auth_url = base_auth_url
         self.base_api_url = base_api_url
         self.user_name = user_name
         self.password = password
+        self.session_params = session_params
 
         auth_endpoint = self.get_auth_endpoint()
         auth = requests.auth.HTTPBasicAuth(self.user_name, self.password)
@@ -607,7 +614,7 @@ class CDEApiConnectionManager:
         }
 
         connection = CDEApiConnection(
-            self.base_api_url, self.access_token, self.api_headers
+            self.base_api_url, self.access_token, self.api_headers, self.session_params
         )
 
         return connection

--- a/dbt/adapters/spark_cde/connections.py
+++ b/dbt/adapters/spark_cde/connections.py
@@ -89,6 +89,7 @@ class SparkCredentials(Credentials):
     server_side_parameters: Dict[str, Any] = field(default_factory=dict)
     retry_all: bool = False
     usage_tracking: Optional[bool] = True
+    cde_session_parameters: Dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def __pre_deserialize__(cls, data):
@@ -459,7 +460,11 @@ class SparkConnectionManager(SQLConnectionManager):
                 elif creds.method == SparkConnectionMethod.CDE:
                     handle = CDEApiSessionConnectionWrapper(
                         CDEApiConnectionManager().connect(
-                            creds.user, creds.password, creds.auth_endpoint, creds.host
+                            creds.user,
+                            creds.password,
+                            creds.auth_endpoint,
+                            creds.host,
+                            creds.cde_session_parameters
                         )
                     )
                     try:


### PR DESCRIPTION
A new optional dict type cde_session_parameters is introduced in the dbt profile that allows one to pass a key=value configuration to the CDE session.

Internal Ticket: https://jira.cloudera.com/browse/DBT-301

Testplan:
Use a dbt profile something like:
<pre>
demodbt:
  target: dev_spark_cde
  outputs:
   dev_spark_cde:
     type: spark_cde
     method: cde
     schema: dbtdemo
     user: [USER]
     password: [PASSWD]
     auth_endpoint: [AUTH_ENDPOINT]
     host: [HOST_ENDPOINT]
     cde_session_parameters:
       fs.s3.canned.acl: BucketOwnerFullControl
       fs.s3a.acl.default: BucketOwnerFullControl
       spark.hadoop.fs.s3a.acl.default: BucketOwnerFullControl
       fs.s3a.server-side-encryption-algorithm: AES256
       fs.s3.server-side-encryption-algorithm: AES256
       spark.kerberos.access.hadoopFileSystems: [SOME-VALUE]
</pre>
Use the CDE Jobs UI to check if the job has the above configuration.
See the attached screenshot of one such configuration.

![image](https://user-images.githubusercontent.com/4781546/188794155-543154a2-8e06-4978-9bfc-b004308a2f53.png)
