### PR TITLE
Fix an issue where second run of the incremental model would fail

### DIFF
--- a/dbt/adapters/spark_cde/cdeapisession.py
+++ b/dbt/adapters/spark_cde/cdeapisession.py
@@ -18,6 +18,7 @@ import datetime as dt
 import dbt.exceptions
 import io
 import json
+import agate
 import random
 import requests
 import time
@@ -200,6 +201,10 @@ class CDEApiCursor:
                     "Error while executing query: "
                     + repr(job_status)
                     + "\n"
+                    + "SQL: "
+                    + sql
+                    + "\n"
+                    + "Error: "
                     + failed_job_output.text
                 )
             # timeout to avoid resource starvation
@@ -436,6 +441,26 @@ class CDEApiConnection:
 
         return res
 
+    def convert_rows(self, schema, rows):
+        """
+            convert row list into agate.Row list
+        """
+        raw_rows = []
+
+        n_items = len(schema)
+        col_names = list(map(lambda x: x['name'], schema))
+        for row in rows:
+            n_cols = len(row)
+            rec = []
+            for idx in range(n_items):
+                if idx < n_cols:
+                    rec.append(row[idx])
+                else:
+                    rec.append(None)
+            raw_rows.append(agate.Row(rec, col_names))
+
+        return schema, raw_rows
+
     def parse_query_result(self, res_lines):
         schema = []
         rows = []
@@ -480,7 +505,8 @@ class CDEApiConnection:
         if len(rows) > 0:
             try:
                 schema, rows = self.extract_datatypes(schema, rows)
-            except Exception:
+                schema, rows = self.convert_rows(schema, rows)
+            except Exception as ex:
                 logger.error(traceback.format_exc())
 
         return schema, rows
@@ -508,7 +534,7 @@ class CDEApiConnection:
         params = {"type": "driver" + "/" + log_type, "follow": "true"}
         res = requests.get(req_url, params=params, headers=self.api_header)
         # parse the o/p for data
-        res_lines = list(map(lambda x: x.strip(), res.text.split("\n")))
+        res_lines = res.text.split("\n")
         if log_type == "stdout":
             schema, rows = self.parse_query_result(res_lines)
             return schema, rows, res

--- a/dbt/adapters/spark_cde/connections.py
+++ b/dbt/adapters/spark_cde/connections.py
@@ -588,7 +588,7 @@ def track_usage(data):
     # prod creds
     headers = {
         "x-api-key": config("SNOWPLOW_API_KEY"),
-        "x-datacoral-environment": config("SNOWPLOW_ENNV"),
+        "x-datacoral-environment": config("SNOWPLOW_ENV"),
         "x-datacoral-passthrough": "true",
     }
 

--- a/dbt/include/spark_cde/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/spark_cde/macros/materializations/incremental/incremental.sql
@@ -32,7 +32,9 @@
     {% do adapter.drop_relation(existing_relation) %}
     {% set build_sql = create_table_as(False, target_relation, sql) %}
   {% else %}
-    {% do run_query(create_table_as(True, tmp_relation, sql)) %}
+    {% do adapter.drop_relation(tmp_relation.incorporate(type='table')) %}
+    {% do adapter.drop_relation(tmp_relation.incorporate(type='view')) %}
+    {% do run_query(create_table_as(False, tmp_relation, sql)) %}
     {% do process_schema_changes(on_schema_change, tmp_relation, existing_relation) %}
     {% set build_sql = dbt_spark_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key) %}
   {% endif %}
@@ -40,6 +42,9 @@
   {%- call statement('main') -%}
     {{ build_sql }}
   {%- endcall -%}
+
+  {% do adapter.drop_relation(tmp_relation.incorporate(type='table')) %}
+  {% do adapter.drop_relation(tmp_relation.incorporate(type='view')) %}
 
   {% do persist_docs(target_relation, model) %}
 


### PR DESCRIPTION
### Describe your changes
This PR address an issue where the second incremental run failed when using dbt-spark-cde. Resolution:
* fix the parsing of results
* change the way the rows are returned to dbt by wrapping in agate.Row object instead of standard list
* change the incremental model code to create a standard temporary table instead of create temporary table/view ddl

### Ticket
Internal: https://jira.cloudera.com/browse/DBT-319

### Testing procedure
For a dbt project with incremental model, first perform a full refresh and then do a selected run of the incremental model. The second run should succeed. The output will be similar to the following runs on a demo project:

(dev-dbt-spark-cde) ganesh.venkateshwara@ganesh dbtdemo % dbt run --full-refresh 
09:39:40  Running with dbt=1.1.2
09:39:40  Found 3 models, 4 tests, 0 snapshots, 0 analyses, 210 macros, 0 operations, 1 seed file, 0 sources, 0 exposures, 0 metrics 09:39:40
09:45:00  Concurrency: 1 threads (target='dev_spark_cde_demo') 09:45:00
09:45:00  1 of 3 START table model dbtdemocde.my_first_dbt_model ......................... [RUN] 
09:50:18  1 of 3 OK created table model dbtdemocde.my_first_dbt_model .................... [OK in 317.55s] 
09:50:18  2 of 3 START incremental model dbtdemocde.my_incremental_model ................. [RUN] 
10:00:52  2 of 3 OK created incremental model dbtdemocde.my_incremental_model ............ [OK in 633.74s]
10:00:52  3 of 3 START table model dbtdemocde.my_second_dbt_model ........................ [RUN] 
10:06:44  3 of 3 OK created table model dbtdemocde.my_second_dbt_model ................... [OK in 352.86s] 
10:06:46
10:06:46  Finished running 2 table models, 1 incremental model in 1625.37s. 10:06:46
10:06:46  Completed successfully
10:06:46
10:06:46  Done. PASS=3 WARN=0 ERROR=0 SKIP=0 TOTAL=3

(dev-dbt-spark-cde) ganesh.venkateshwara@ganesh dbtdemo % dbt run --select models/example/my_incremental_model.sql 10:07:12  Running with dbt=1.1.2
10:07:12  Found 3 models, 4 tests, 0 snapshots, 0 analyses, 210 macros, 0 operations, 1 seed file, 0 sources, 0 exposures, 0 metrics 
10:07:12
10:12:30  Concurrency: 1 threads (target='dev_spark_cde_demo') 
10:12:30
10:12:30  1 of 1 START incremental model dbtdemocde.my_incremental_model ................. [RUN] 
10:40:25  1 of 1 OK created incremental model dbtdemocde.my_incremental_model ............ [OK in 1675.63s] 
10:40:27
10:40:27  Finished running 1 incremental model in 1994.70s. 
10:40:27
10:40:27  Completed successfully
10:40:27
10:40:27  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1

### Checklist for review
- [X] I have performed a self-review of my code
- [X] I have formatted my added/modified code to follow peop-8 standards
- [X] I have checked suggestions from pylint to make sure code is of good quality

