### PR TITLE
Fetch stderr logs for spark driver

### DIFF
--- a/dbt/adapters/spark_cde/cdeapisession.py
+++ b/dbt/adapters/spark_cde/cdeapisession.py
@@ -18,6 +18,7 @@ import datetime as dt
 import dbt.exceptions
 import io
 import json
+import os
 import random
 import requests
 import time
@@ -184,8 +185,11 @@ class CDEApiCursor:
             )
             logger.debug("{}: Done get job status".format(job_name))
 
-            # throw exception and print to console for failed job.
-            if job_status["status"] == CDEApiConnection.JOB_STATUS["failed"]:
+            # throw exception and print to console for failed/killed job.
+            if (
+                job_status["status"] == CDEApiConnection.JOB_STATUS["failed"]
+                or job_status["status"] == CDEApiConnection.JOB_STATUS["killed"]
+            ):
                 logger.debug("{}: Get job output".format(job_name))
                 schema, rows, failed_job_output = self._cde_connection.get_job_output(
                     job_name, job
@@ -196,6 +200,12 @@ class CDEApiCursor:
                         job_name, failed_job_output.text
                     )
                 )
+                logger.debug("{}: Log failed job stderr output".format(job_name))
+                self.log_spark_driver_errors(job, job_name)
+                logger.debug(
+                    "{}: Done logging failed job stderr output".format(job_name)
+                )
+
                 raise dbt.exceptions.raise_database_error(
                     "Error while executing query: "
                     + repr(job_status)
@@ -235,6 +245,26 @@ class CDEApiCursor:
         logger.debug("{}: Delete resource".format(job_name))
         self._cde_connection.delete_resource(job_name)
         logger.debug("{}: Done delete resource".format(job_name))
+
+    """
+    Fetch spark driver stderr log and create a new log file with job name which has failed
+    """
+    def log_spark_driver_errors(self, job, job_name):
+        try:
+            events, failed_job_stderr = self._cde_connection.get_job_output(
+                job_name, job, log_type="stderr"
+            )
+
+            error_file_name = job_name + ".stderr.log"
+            directory = os.path.join(os.getcwd(), "logs", error_file_name)
+
+            with open(directory, "w") as file:
+                file.write(failed_job_stderr)
+
+        except Exception as ex:
+            logger.error(
+                "{}: Failed to get job spark driver stderr output. {}".format(job_name, ex)
+            )
 
     """
     Fetch spark events from log and log them along with their corresponding timestamps
@@ -318,6 +348,7 @@ class CDEApiConnection:
         "running": "running",
         "succeeded": "succeeded",
         "failed": "failed",
+        "killed": "killed",
     }
 
     def __init__(self, base_api_url, access_token, api_header, session_params) -> None:

--- a/dbt/adapters/spark_cde/cdeapisession.py
+++ b/dbt/adapters/spark_cde/cdeapisession.py
@@ -207,10 +207,8 @@ class CDEApiCursor:
                 )
 
                 raise dbt.exceptions.raise_database_error(
-                    "Error while executing query: "
-                    + repr(job_status)
-                    + "\n"
-                    + failed_job_output.text
+                    "Error while executing CDE Job: "
+                    + job_name
                 )
             # timeout to avoid resource starvation
             if total_time_spent_in_get_job_status >= DEFAULT_CDE_JOB_TIMEOUT:
@@ -259,7 +257,7 @@ class CDEApiCursor:
             directory = os.path.join(os.getcwd(), "logs", error_file_name)
 
             with open(directory, "w") as file:
-                file.write(failed_job_stderr)
+                file.write(failed_job_stderr.text)
 
         except Exception as ex:
             logger.error(


### PR DESCRIPTION
## Describe your changes
Added code to fetch logs from stderr for spark driver incase of job failures.

## Internal Jira ticket number or external issue link
[Internal JIRA ticket](https://jira.cloudera.com/browse/DBT-406)
## Testing procedure/screenshots(if appropriate):

- Started a dbt debug command
- Killed the job created while in progress so that it fails.
![image](https://user-images.githubusercontent.com/2308360/191966278-a948432d-ca1a-4827-af1a-46a98995d539.png)

![image](https://user-images.githubusercontent.com/2308360/191966718-bd779ad9-c0d6-420f-be17-d8006e3c04bc.png)

- Made sure new file is created in dbt log folder with the stderr output
- Attaching new file created. 
[dbt-job-1663938116617-00000255.stderr.log](https://github.com/cloudera/dbt-spark-cde/files/9633822/dbt-job-1663938116617-00000255.stderr.log)

- Made sure code is not breaking existing changes. Dbt run 
![image](https://user-images.githubusercontent.com/2308360/191966073-236638b0-590b-4d6b-b0e2-c5e6211c0c21.png)


## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have formatted my added/modified code to follow pep-8 standards
- [X] I have checked suggestions from python linter to make sure code is of good quality.