### PR TITLE
[DBT-495] add warehouse version information in instrumentation

### DIFF
--- a/dbt/adapters/spark_cde/impl.py
+++ b/dbt/adapters/spark_cde/impl.py
@@ -1,7 +1,8 @@
 import re
+import json
 from concurrent.futures import Future
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union, OrderedDict
 from typing_extensions import TypeAlias
 
 import agate
@@ -13,6 +14,7 @@ import dbt.exceptions
 from dbt.adapters.base import AdapterConfig
 from dbt.adapters.base.impl import catch_as_completed
 from dbt.adapters.sql import SQLAdapter
+import dbt.adapters.spark_cde.cloudera_tracking as tracker
 from dbt.adapters.spark_cde import SparkConnectionManager
 from dbt.adapters.spark_cde import SparkRelation
 from dbt.adapters.spark_cde import SparkColumn
@@ -380,6 +382,38 @@ class SparkAdapter(SQLAdapter):
         finally:
             conn.transaction_open = False
 
+    def debug_query(self) -> None:
+        self.execute("select 1 as id")
+
+        # query warehouse version
+        try:
+            sql_query = "select version()"
+            _, table = self.execute(sql_query, True, True)
+            version_object = []
+            json_funcs = [c.jsonify for c in table.column_types]
+
+            for row in table.rows:
+                values = tuple(json_funcs[i](d) for i, d in enumerate(row))
+                version_object.append(OrderedDict(zip(row.keys(), values)))
+
+            version_json = json.dumps(version_object)
+
+            payload = {
+                "event_type": "dbt_spark_cde_warehouse",
+                "warehouse_version": version_json,
+            }
+            tracker.track_usage(payload)
+        except Exception as ex:
+            logger.error(
+                f"Failed to fetch warehouse version. Exception: {ex}"
+            )
+            payload = {
+                "event_type": "dbt_spark_cde_warehouse",
+                "warehouse_version": "NA",
+            }
+            tracker.track_usage(payload)
+
+        self.connections.get_thread_connection().handle.close()
 
 # spark does something interesting with joins when both tables have the same
 # static values for the join condition and complains that the join condition is


### PR DESCRIPTION
## Describe your changes
Add warehouse version information in instrumentation.
Works for Spark3 and higher. 

## Internal Jira ticket number or external issue link
DBT-495 (internal) 

## Testing procedure/screenshots(if appropriate):
For a valid dbt-spark-cde profile, with a dbt debug, the logs will have a record similar to the following:

12:15:40.899638 [debug] [Thread-5 (]: Tracker adapter: Sending Event [{"data": {"event_type": "dbt_spark_cde_warehouse", "warehouse_version": "[{\"version()\": \"3.2.0 2a37d1667c5d9b5a6059c1ea1ed898fc149543a3\"}]", "auth": "N/A", "connection_state": "N/A", "elapsed_time": "N/A", "incremental_strategy": "N/A", "model_name": "N/A", "model_type": "N/A", "permissions": "N/A", "profile_name": "N/A", "sql_type": "N/A", "id": "995fee16-4183-48f0-ab96-1db082db9d8a", "unique_host_hash": "7a7362cc11cc7b364376545557b9e440", "unique_user_hash": "e8a5d78ea632435d797d3d58df650872", "unique_session_hash": "7d36e084f3289f4b1fc0c5ea974d4e03", "python_version": "3.10.6", "system": "Darwin", "machine": "arm64", "platform": "macOS-12.6-arm64-arm-64bit", "dbt_version": "1.1.2", "dbt_adapter": "spark_cde-1.1.4", ... }}]

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have formatted my added/modified code to follow pep-8 standards
- [X] I have checked suggestions from python linter to make sure code is of good quality.