### PR TITLE
ensure existing table / view is dropped before attempting to create incremental models

### DIFF
--- a/dbt/include/spark_cde/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/spark_cde/macros/materializations/incremental/incremental.sql
@@ -37,6 +37,8 @@
 
   {#-- Incremental run logic --#}
   {%- if existing_relation is none -%}
+    {% do adapter.drop_relation(target_relation.incorporate(type='table')) %}
+    {% do adapter.drop_relation(target_relation.incorporate(type='view')) %}
     {#-- Relation must be created --#}
     {%- call statement('main', language=language) -%}
       {{ create_table_as(False, target_relation, compiled_code, language) }}
@@ -46,6 +48,8 @@
     {% set is_delta = (file_format == 'delta' and existing_relation.is_delta) %}
     {% if not is_delta %} {#-- If Delta, we will `create or replace` below, so no need to drop --#}
       {% do adapter.drop_relation(existing_relation) %}
+      {% do adapter.drop_relation(target_relation.incorporate(type='table')) %}
+      {% do adapter.drop_relation(target_relation.incorporate(type='view')) %}
     {% endif %}
     {%- call statement('main', language=language) -%}
       {{ create_table_as(False, target_relation, compiled_code, language) }}


### PR DESCRIPTION
When using full refresh mode, ensure table / view is dropped before attempting to create the incremental model. 

Test:
run dbt-spar-cde-example project containing incremental model, with --full-refresh and then without, the models should be built correctly.
<pre>
(dev-dbt-spark-cde) ganesh.venkateshwara@ganesh dbt_spark_cde_demo % dbt run -t cloudera-cia-spark_cde --full-refresh
02:05:12  Running with dbt=1.3.1
02:05:12  Found 2 models, 13 tests, 0 snapshots, 0 analyses, 331 macros, 0 operations, 4 seed files, 2 sources, 0 exposures, 0 metrics
02:05:12  
02:15:49  Concurrency: 1 threads (target='cloudera-cia-spark_cde')
02:15:49  
02:15:49  1 of 2 START sql view model spark_cde_demo_staging_covid.stg_covid__cases ...... [RUN]
02:17:29  1 of 2 OK created sql view model spark_cde_demo_staging_covid.stg_covid__cases . [OK in 100.27s]
02:17:29  2 of 2 START sql incremental model spark_cde_demo_mart_covid.covid_cases ....... [RUN]
02:25:50  2 of 2 OK created sql incremental model spark_cde_demo_mart_covid.covid_cases .. [OK in 501.57s]
02:25:51  
02:25:51  Finished running 1 view model, 1 incremental model in 0 hours 20 minutes and 39.59 seconds (1239.59s).
02:25:51  
02:25:51  Completed successfully
02:25:51  
02:25:51  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2

(dev-dbt-spark-cde) ganesh.venkateshwara@ganesh dbt_spark_cde_demo % dbt run -t cloudera-cia-spark_cde               
02:26:07  Running with dbt=1.3.1
02:26:07  Found 2 models, 13 tests, 0 snapshots, 0 analyses, 331 macros, 0 operations, 4 seed files, 2 sources, 0 exposures, 0 metrics
02:26:07  
02:36:27  Concurrency: 1 threads (target='cloudera-cia-spark_cde')
02:36:27  
02:36:27  1 of 2 START sql view model spark_cde_demo_staging_covid.stg_covid__cases ...... [RUN]
02:38:10  1 of 2 OK created sql view model spark_cde_demo_staging_covid.stg_covid__cases . [OK in 102.58s]
02:38:10  2 of 2 START sql incremental model spark_cde_demo_mart_covid.covid_cases ....... [RUN]
02:46:46  2 of 2 OK created sql incremental model spark_cde_demo_mart_covid.covid_cases .. [OK in 516.79s]
02:46:47  
02:46:47  Finished running 1 view model, 1 incremental model in 0 hours 20 minutes and 40.79 seconds (1240.79s).
02:46:47  
02:46:47  Completed successfully
02:46:47  
02:46:47  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2
</pre>