### PR TITLE
split dbt_adapter filed in instrumentation to dbt_adapter_type and dbt_adapte…

### DIFF
--- a/dbt/adapters/spark_cde/cloudera_tracking.py
+++ b/dbt/adapters/spark_cde/cloudera_tracking.py
@@ -65,7 +65,8 @@ def populate_platform_info(cred: Credentials, ver):
         "dbt_version"
     ] = dbt.version.get_installed_version().to_version_string(skip_matcher=True)
     # dbt adapter info e.g. impala-1.2.0
-    platform_info["dbt_adapter"] = f"{cred.type}-{ver.version}"
+    platform_info["dbt_adapter_type"] = f"{cred.type}"
+    platform_info["dbt_adapter_version"] = f"{ver.version}"
 
 def populate_dbt_deployment_env_info():
     """


### PR DESCRIPTION
Split dbt_adapter field  in instrumentation to adapter_type and adapter_version

Test Result:
{'data': '{"event_type": "dbt_spark_cde_close", "connection_state": "closed", "elapsed_time": "0.00", "auth": "N/A", "incremental_strategy": "N/A", "model_name": "N/A", "model_type": "N/A", "permissions": "N/A", "profile_name": "N/A", "sql_type": "N/A", "id": "ea170736-1c4b-4ff0-b8e3-6019fbe12995", "unique_host_hash": "7a7362cc11cc7b364376545557b9e440", "unique_user_hash": "e8a5d78ea632435d797d3d58df650872", "unique_session_hash": "38f850234412253dd7856e483fcd99d3", "python_version": "3.10.7", "system": "Darwin", "machine": "arm64", "platform": "macOS-13.0.1-arm64-arm-64bit", **"dbt_version": "1.3.1", "dbt_adapter_type": "spark_cde"**, "dbt_adapter_version": "1.3.0", "dbt_deployment_env": {}, "project_name": "dbt_spark_cde_demo", "target_name": "cloudera_cia_dev_cde_demo", "no_of_threads": 4}'}
