### PR TITLE
merge node_id and model_name into one key: model_name

### DIFF
--- a/dbt/adapters/spark_cde/connections.py
+++ b/dbt/adapters/spark_cde/connections.py
@@ -664,7 +664,10 @@ class SparkConnectionManager(SQLConnectionManager):
             }
 
             for key, value in additional_info.items():
-                payload[key] = value
+                if key == "node_id":
+                    payload["model_name"] = value
+                else:
+                    payload[key] = value
 
             tracker.track_usage(payload)
 


### PR DESCRIPTION
Merge node_id and model_name into one key: model_name

Sample event payload:
<pre>
[0m13:27:00.496970 [debug] [Thread-15 ]: Tracker adapter: Sending Event {'data': '{"event_type": "dbt_spark_cde_model_access", "model_name": "spark_cde_demo.my_first_dbt_model", "model_type": "table", "incremental_strategy": "", "auth": "N/A", "connection_state": "N/A", "elapsed_time": "N/A", "permissions": "N/A", "profile_name": "N/A", "sql_type": "N/A", "id": "00669254-558a-4b7c-adc5-e8ef19d1a318", "unique_host_hash": "7a7362cc11cc7b364376545557b9e440", "unique_user_hash": "e8a5d78ea632435d797d3d58df650872", "unique_session_hash": "f3a73503700da5ad4325550e02fe691a", "python_version": "3.9.12", "system": "Darwin", "machine": "arm64", "platform": "macOS-13.0.1-arm64-arm-64bit", "dbt_version": "1.3.1", "dbt_adapter_type": "spark_cde", "dbt_adapter_version": "1.3.0", "dbt_deployment_env": {}, "project_name": "dbtdemo", "target_name": "cloudera-cia-spark_cde", "no_of_threads": 1}'}
</pre>