### PR TITLE
refactor cloudera_tracking: event type as enums, optional userkey, warehouse version fetch 

### DIFF
--- a/dbt/adapters/spark_cde/cloudera_tracking.py
+++ b/dbt/adapters/spark_cde/cloudera_tracking.py
@@ -27,6 +27,15 @@ from dbt.adapters.base import Credentials
 from dbt.events import AdapterLogger
 from decouple import config
 
+# all event types
+class TrackingEventType:
+    DEBUG = "debug_and_fetch_permission"
+    OPEN = "open"
+    CLOSE = "close"
+    START_QUERY = "start_query"
+    END_QUERY = "end_query"
+    INCREMENTAL = "incremental"
+    MODEL_ACCESS = "model_access"
 
 # global logger
 logger = AdapterLogger("Tracker")
@@ -45,6 +54,9 @@ profile_info = {}
 
 # Json object to store dbt deployment environment variables
 dbt_deployment_env_info = {}
+
+# Json object for warehouse information
+warehouse_info = { "warehouse_version": { "version": "NA", "build": "NA" } }
 
 def populate_platform_info(cred: Credentials, ver):
     """
@@ -75,9 +87,9 @@ def populate_dbt_deployment_env_info():
     default_value = "{}"  # if environment variables doesn't exist add empty json as default
     dbt_deployment_env_info["dbt_deployment_env"] = json.loads(os.environ.get('DBT_DEPLOYMENT_ENV', default_value))
 
-def populate_unique_ids(cred: Credentials):
+def populate_unique_ids(cred: Credentials, userkey="username"):
     host = str(cred.host).encode()
-    user = str(cred.user).encode()
+    user = str(getattr(cred, userkey)).encode()
     timestamp = str(time.time()).encode()
 
     # dbt invocation id
@@ -93,7 +105,6 @@ def populate_unique_ids(cred: Credentials):
     # hashed session
     unique_ids["unique_session_hash"] = hashlib.md5(host + user + timestamp).hexdigest()
 
-
 def generate_profile_info(self):
     if not profile_info:
         # name of dbt project in profiles
@@ -103,6 +114,9 @@ def generate_profile_info(self):
         # number of threads in profiles
         profile_info["no_of_threads"] = self.profile.threads
 
+def populate_warehouse_info(w_info):
+    warehouse_info["warehouse_version"]["version"] = w_info["version"]
+    warehouse_info["warehouse_version"]["build"] = w_info["build"]
 
 def _merge_keys(source_dict, dest_dict):
     for key, value in source_dict.items():
@@ -188,6 +202,7 @@ def track_usage(tracking_payload):
     tracking_payload = _merge_keys(platform_info, tracking_payload)
     tracking_payload = _merge_keys(dbt_deployment_env_info, tracking_payload)
     tracking_payload = _merge_keys(profile_info, tracking_payload)
+    tracking_payload = _merge_keys(warehouse_info, tracking_payload)
 
     # form the tracking data
     tracking_data = {"data": json.dumps(tracking_payload)}
@@ -214,6 +229,8 @@ def track_usage(tracking_payload):
             "x-datacoral-passthrough": "true",
         }
 
+        logger.debug(f"Sending Event {data}")
+
         data = json.dumps([data])
 
         res = None
@@ -228,8 +245,6 @@ def track_usage(tracking_payload):
             usage_tracking = False
 
         return res
-
-    logger.debug(f"Sending Event {tracking_data}")
 
     # call the tracking function in a Thread
     the_track_thread = threading.Thread(

--- a/dbt/adapters/spark_cde/connections.py
+++ b/dbt/adapters/spark_cde/connections.py
@@ -117,7 +117,7 @@ class SparkCredentials(Credentials):
         # get dbt deployment env information for tracking
         tracker.populate_dbt_deployment_env_info()
         # generate unique ids for tracking
-        tracker.populate_unique_ids(self)
+        tracker.populate_unique_ids(self, "user")
         
         # spark classifies database and schema as the same thing
         if self.database is not None and self.database != self.schema:
@@ -504,6 +504,9 @@ class SparkConnectionManager(SQLConnectionManager):
                         )
                         connection_end_time = time.time()
                         connection.state = ConnectionState.OPEN
+
+                        # doing any extra query with CDE is expensive, so commenting this out
+                        # SparkConnectionManager.fetch_spark_version(handle)
                     except Exception as ex:
                         logger.debug("Connection error: {}".format(ex))
                         connection_ex = ex
@@ -512,7 +515,7 @@ class SparkConnectionManager(SQLConnectionManager):
 
                     # track usage
                     payload = {
-                        "event_type": "dbt_spark_cde_open",
+                        "event_type": tracker.TrackingEventType.OPEN,
                         "auth": "cde",
                         "connection_state": connection.state,
                         "elapsed_time": "{:.2f}".format(
@@ -583,7 +586,7 @@ class SparkConnectionManager(SQLConnectionManager):
             connection_close_end_time = time.time()
 
             payload = {
-                "event_type": "dbt_spark_cde_close",
+                "event_type": tracker.TrackingEventType.CLOSE,
                 "connection_state": ConnectionState.CLOSED,
                 "elapsed_time": "{:.2f}".format(
                     connection_close_end_time - connection_close_start_time
@@ -597,35 +600,27 @@ class SparkConnectionManager(SQLConnectionManager):
             logger.debug(f"Error closing connection {err}")
 
     @classmethod
-    def fetch_spark_version(cls, connection):
+    def fetch_spark_version(cls, handle):
 
         if SparkConnectionManager.spark_version: 
             return SparkConnectionManager.spark_version
 
         try:
             sql = "select version()"
-            cursor = connection.handle.cursor()
+            cursor = handle.cursor()
             cursor.execute(sql)
 
             res = cursor.fetchall()
 
             SparkConnectionManager.spark_version = res[0][0].split(".")[0]
 
-            payload = {
-                "event_type": "dbt_spark_cde_warehouse",
-                "warehouse_version": { "version": SparkConnectionManager.spark_version, "build": res[0][0] },
-            }
-            tracker.track_usage(payload)
+            tracker.populate_warehouse_info({ "version": SparkConnectionManager.spark_version, "build": res[0][0] })
         except Exception as ex:
             # we couldn't get the spark warehouse version, default to version 2
             logger.debug(f"Cannot get spark version, defaulting to version 2. Error: {ex}")
             SparkConnectionManager.spark_version = "2"
 
-            payload = {
-                "event_type": "dbt_spark_cde_warehouse",
-                "warehouse_version": { "version": "2", "build": "NA" },
-            }
-            tracker.track_usage(payload)
+            tracker.populate_warehouse_info({ "version": SparkConnectionManager.spark_version, "build": res[0][0] })
 
         os.environ['DBT_SPARK_VERSION'] = SparkConnectionManager.spark_version 
         logger.debug(f"SPARK VERSION {os.getenv('DBT_SPARK_VERSION')}")
@@ -658,7 +653,7 @@ class SparkConnectionManager(SQLConnectionManager):
 
             # track usage
             payload = {
-                "event_type": "dbt_spark_cde_start_query",
+                "event_type": tracker.TrackingEventType.START_QUERY,
                 "sql": log_sql,
                 "profile_name": self.profile.profile_name
             }
@@ -690,7 +685,7 @@ class SparkConnectionManager(SQLConnectionManager):
             elapsed_time = time.time() - pre
 
             payload = {
-                "event_type": "dbt_spark_cde_end_query",
+                "event_type": tracker.TrackingEventType.END_QUERY,
                 "sql": log_sql,
                 "elapsed_time": "{:.2f}".format(elapsed_time),
                 "status": query_status,

--- a/dbt/adapters/spark_cde/relation.py
+++ b/dbt/adapters/spark_cde/relation.py
@@ -35,7 +35,7 @@ class SparkRelation(BaseRelation):
         if self.type:
             tracker.track_usage(
                 {
-                    "event_type": "dbt_spark_cde_model_access",
+                    "event_type": tracker.TrackingEventType.MODEL_ACCESS, 
                     "model_name": self.render(),
                     "model_type": self.type,
                     "incremental_strategy": "",
@@ -54,7 +54,7 @@ class SparkRelation(BaseRelation):
         if self.type:
             tracker.track_usage(
                 {
-                    "event_type": "dbt_spark_cde_new_incremental",
+                    "event_type": tracker.TrackingEventType.INCREMENTAL,
                     "model_name": self.render(),
                     "model_type": self.type,
                     "incremental_strategy": incremental_strategy,


### PR DESCRIPTION
## Describe your changes
* modify populate_unique_ids to provide optional userkey
* refactor warehouse key, add event type enums
* use the refactored tracking lib: event type, warehouse version 

## Testing:
Using dbt debug, a sample tacking payload in dbt.logs:
<pre>
[0m14:37:53.509049 [debug] [Thread-25 ]: Tracker adapter: Sending Event {'data': '{"event_type": "end_query", "elapsed_time": "157.15", "status": "OK", "profile_name": "dbtdemo", "sql_type": "create table", "auth": "N/A", "connection_state": "N/A", "incremental_strategy": "N/A", "model_name": "N/A", "model_type": "N/A", "permissions": "N/A", "id": "6702c164-d557-4e31-a80a-778a276353cd", "unique_host_hash": "7a7362cc11cc7b364376545557b9e440", "unique_user_hash": "e8a5d78ea632435d797d3d58df650872", "unique_session_hash": "127f1714fcaac153490f147bce970793", "python_version": "3.9.12", "system": "Darwin", "machine": "arm64", "platform": "macOS-13.0.1-arm64-arm-64bit", "dbt_version": "1.3.1", "dbt_adapter_type": "spark_cde", "dbt_adapter_version": "1.3.0", "dbt_deployment_env": {}, "project_name": "dbtdemo", "target_name": "cloudera-cia-spark_cde", "no_of_threads": 1, "warehouse_version": {"version": "NA", "build": "NA"}}'}
</pre>