### PR TITLE
address an issue with empty coluns being incorrectly parsed

### DIFF
--- a/dbt/adapters/spark_cde/cdeapisession.py
+++ b/dbt/adapters/spark_cde/cdeapisession.py
@@ -558,7 +558,7 @@ class CDEApiConnection:
             row = list(
                 map(
                     lambda x: x.strip(),
-                    list(filter(lambda x: x.strip() != "", data_line.split("|", n_columns))),
+                    data_line.split("|", n_columns),
                 )
             )
             rows.append(row)


### PR DESCRIPTION
Empty columns were completely neglected instead of retaining them, this PR fixes this issue.
This affected the way incremental run was done the second time. 


Test:
Run incremental model multiple times should succeed:
<pre>

(dev-dbt-spark-cde) ganesh.venkateshwara@ganesh dbt_spark_cde_demo % dbt run -t cloudera-cia-spark_cde 
10:52:45  Running with dbt=1.3.1
10:52:45  Found 2 models, 13 tests, 0 snapshots, 0 analyses, 331 macros, 0 operations, 4 seed files, 2 sources, 0 exposures, 0 metrics
10:52:45  
11:12:57  Concurrency: 1 threads (target='cloudera-cia-spark_cde')
11:12:57  
11:12:57  1 of 2 START sql view model spark_cde_demo_staging_covid.stg_covid__cases ...... [RUN]
11:15:32  1 of 2 OK created sql view model spark_cde_demo_staging_covid.stg_covid__cases . [OK in 154.62s]
11:15:32  2 of 2 START sql incremental model spark_cde_demo_mart_covid.covid_cases ....... [RUN]
11:27:54  2 of 2 OK created sql incremental model spark_cde_demo_mart_covid.covid_cases .. [OK in 742.48s]
11:27:55  
11:27:55  Finished running 1 view model, 1 incremental model in 0 hours 35 minutes and 10.16 seconds (2110.16s).
11:27:55  
11:27:55  Completed successfully
11:27:55  
11:27:55  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2

(dev-dbt-spark-cde) ganesh.venkateshwara@ganesh dbt_spark_cde_demo % dbt run -t cloudera-cia-spark_cde 
12:38:59  Running with dbt=1.3.1
12:38:59  Unable to do partial parsing because profile has changed
12:39:00  Found 2 models, 13 tests, 0 snapshots, 0 analyses, 331 macros, 0 operations, 4 seed files, 2 sources, 0 exposures, 0 metrics
12:39:00  
12:47:14  Concurrency: 4 threads (target='cloudera-cia-spark_cde')
12:47:14  
12:47:14  1 of 2 START sql view model spark_cde_demo_staging_covid.stg_covid__cases ...... [RUN]
12:49:48  1 of 2 OK created sql view model spark_cde_demo_staging_covid.stg_covid__cases . [OK in 154.52s]
12:49:48  2 of 2 START sql incremental model spark_cde_demo_mart_covid.covid_cases ....... [RUN]
13:02:35  2 of 2 OK created sql incremental model spark_cde_demo_mart_covid.covid_cases .. [OK in 767.05s]
13:02:36  
13:02:36  Finished running 1 view model, 1 incremental model in 0 hours 23 minutes and 36.27 seconds (1416.27s).
13:02:36  
13:02:36  Completed successfully
13:02:36  
13:02:36  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2
</pre>